### PR TITLE
update qna node to match API V4

### DIFF
--- a/node-red-contrib-ms-oxford/node-qna.html
+++ b/node-red-contrib-ms-oxford/node-qna.html
@@ -82,5 +82,5 @@
 </script>
 
 <script type="text/x-red" data-help-name="ms-qna">
-    <p>Query Microsoft QNA Maker API with the given payload.</p>
+    <p>Query Microsoft QNA Maker API V4 with the given payload.</p>
 </script>

--- a/node-red-contrib-ms-oxford/node-qna.html
+++ b/node-red-contrib-ms-oxford/node-qna.html
@@ -4,16 +4,18 @@
         color: '#3FADB5',
         defaults: { 
             name:               { value: undefined },
+            host:               { value: undefined, required: true },
+            hostType:           { value: "str" },
             knowledgeBaseId:    { value: undefined, required: true },
-            knowledgeType:      { value: "msg" },
-            subKeyType:         { value: "msg" },
+            knowledgeType:      { value: "str" },
+            endpointKeyType:    { value: "str" },
             question:           { value: "payload" },
             questionType:       { value: "msg" },
             output:             { value: "payload" },
             outputType:         { value: "msg" }
         },
         credentials: {
-            subKey:             { type: "text" }
+            endpointKey:        { type: "text" }
         },
         inputs: 1,
         outputs:1,
@@ -22,12 +24,14 @@
         paletteLabel: 'QnA',
         label: function() { return this.name || "QnA"; },
         oneditprepare: function() {
-            if (!this.knowledgeType) this.knowledgeType = 'msg';
-            if (!this.subKeyType) this.subKeyType = 'msg';
+            if (!this.hostType) this.hostType = 'str';
+            if (!this.knowledgeType) this.knowledgeType = 'str';
+            if (!this.endpointKeyType) this.endpointKeyType = 'str';
             if (!this.questionType) this.questionType = 'msg';
             if (!this.outputType) this.outputType = 'msg';
-            $("#node-input-knowledgeBaseId").typedInput({ default: 'msg', types: ['msg','str','global'], typeField: $("#node-input-knowledgeType") });
-            $("#node-input-subKey").typedInput({ default: 'msg', types: ['msg','str','global'], typeField: $("#node-input-subKeyType") });
+            $("#node-input-host").typedInput({ default: 'str', types: ['str','msg','global'], typeField: $("#node-input-hostType") });
+            $("#node-input-knowledgeBaseId").typedInput({ default: 'str', types: ['str','msg','global'], typeField: $("#node-input-knowledgeType") });
+            $("#node-input-endpointKey").typedInput({ default: 'str', types: ['str','msg','global'], typeField: $("#node-input-endpointKeyType") });
             $("#node-input-question").typedInput({ default: 'msg', types: ['msg','str','global'], typeField: $("#node-input-questionType") });
             $("#node-input-output").typedInput({ default: 'msg', types: ['msg','global'], typeField: $("#node-input-outputType") });
         }
@@ -45,9 +49,14 @@
 
     <div class="form-row">
         <br>
-        <label for="node-input-subKey" style="width:160px;"><i class="fa fa-lock"></i> Subscription key</label>
-        <input type="text" id="node-input-subKey" style="width:57%;" placeholder="">
-        <input type="hidden" id="node-input-subKeyType">
+        <label for="node-input-host" style="width:160px;"><i class="fa fa-globe"></i> Host</label>
+        <input type="text" id="node-input-host" style="width:57%;" placeholder="">
+        <input type="hidden" id="node-input-hostType">
+    </div>
+    <div class="form-row">
+        <label for="node-input-endpointKey" style="width:160px;"><i class="fa fa-lock"></i> Endpoint key</label>
+        <input type="text" id="node-input-endpointKey" style="width:57%;" placeholder="">
+        <input type="hidden" id="node-input-endpointKeyType">
     </div>
     <div class="form-row">
         <label for="node-input-knowledgeBaseId" style="width:160px;"><i class="fa fa-globe"></i> Knowledge Base ID</label>

--- a/node-red-contrib-ms-oxford/node-qna.js
+++ b/node-red-contrib-ms-oxford/node-qna.js
@@ -12,46 +12,50 @@ module.exports = function(RED) {
         RED.nodes.createNode(this, config);
         let node = this;
 
-        config.subKey = this.credentials.subKey;
+        config.endpointKey = this.credentials.endpointKey;
 
         this.on('input', (data)  => { input(node, data, config)  });
     }
     RED.nodes.registerType("ms-qna", register, { 
         credentials: {
-            subKey:  { type: "text" }
+            endpointKey:  { type: "text" }
         }
     });
 }
 
 async function input (node, data, config) {
 
-    let knowledgeBaseId = config.knowledgeBaseId,
+    let host = config.host,
+        knowledgeBaseId = config.knowledgeBaseId,
         question = config.question,
         output = config.output,
-        subKey = config.subKey;
+        endpointKey = config.endpointKey;
 
+    if (config.hostType !== 'str') {
+        let loc = (config.hostType === 'global') ? node.context().global : data;
+        host = helper.getByString(loc, host); }
     if (config.knowledgeType !== 'str') {
         let loc = (config.knowledgeType === 'global') ? node.context().global : data;
         knowledgeBaseId = helper.getByString(loc, knowledgeBaseId); }
-    if (config.subKeyType !== 'str') {
-        let loc = (config.subKeyType === 'global') ? node.context().global : data;
-        subKey = helper.getByString(loc, subKey); }
+    if (config.endpointKeyType !== 'str') {
+        let loc = (config.endpointKeyType === 'global') ? node.context().global : data;
+        endpointKey = helper.getByString(loc, endpointKey); }
     if (config.questionType !== 'str') {
         let loc = (config.questionType === 'global') ? node.context().global : data;
         question = helper.getByString(loc, question); }
 
     let questionLoc = (config.outputType === 'global') ? node.context().global : data;
 
-    if (knowledgeBaseId === undefined || subKey === undefined) {
+    if (host === undefined || knowledgeBaseId === undefined ||endpointKey === undefined) {
         return node.status({
             fill:"red", 
             shape:"ring", 
-            text: 'Missing credential'
+            text: 'Missing value'
         });
     }
 
     try {
-        let json = await processRequest(subKey, question, knowledgeBaseId);
+        let json = await processRequest(host, endpointKey, question, knowledgeBaseId);
             json = JSON.parse(json);
 
         const entities = new Entities();
@@ -64,15 +68,15 @@ async function input (node, data, config) {
 
 }
 
-async function processRequest (subKey, question, knowledge) {
-    let url = 'https://westus.api.cognitive.microsoft.com/qnamaker/v2.0/knowledgebases/' + knowledge + '/generateAnswer';
+async function processRequest (host, endpointKey, question, knowledge) {
+    let url = `${host}/qnamaker/knowledgebases/${knowledge}/generateAnswer`;
 
     let req = {
         method: 'POST',
         uri: url,
         headers: {
-            'ContentType': 'application/json',
-            'Ocp-Apim-Subscription-Key': subKey
+            'Content-Type': 'application/json',
+            'Authorization' : `EndpointKey ${endpointKey}`
         },
         body: JSON.stringify({
             "question" : question


### PR DESCRIPTION
This follows the PR created by Tellen to fix the QnA Maker node.

- new "host" field in the node configuration because it's now app specific
- the V4 version of the API doesn't use the subscription key to query the knowledge base but the endpoint key

I also changed the default types for the QnA settings part (host, endpoint key and knowledge base ID) to use a string by default.