### PR TITLE
fix undefined ffExt and ffBase

### DIFF
--- a/node-red-viseo-storage-plugin/projects/index.js
+++ b/node-red-viseo-storage-plugin/projects/index.js
@@ -79,15 +79,15 @@ function init(_settings, _runtime) {
         flowsFile = 'flows_'+require('os').hostname()+'.json';
         flowsFullPath = fspath.join(settings.userDir,flowsFile);
     }
+    
+    var ffExt = fspath.extname(flowsFullPath);
+    var ffBase = fspath.basename(flowsFullPath,ffExt);
 
     if(settings.credentialsFile) {
         cfName = settings.credentialsFile;
     } else {
         cfName = ffBase+"_cred"+ffExt;
     }
-
-    var ffExt = fspath.extname(flowsFullPath);
-    var ffBase = fspath.basename(flowsFullPath,ffExt);
 
     flowsFileBackup = getBackupFilename(flowsFullPath);
     credentialsFile = fspath.join(settings.userDir, cfName);


### PR DESCRIPTION
When project is disabled and no credential file is configured in the settings, node-red doesn't find the credential files.
This is because the storage module uses some variables (ffBase and ffExt) that are not defined at this time.