### PR TITLE
Add a node to transfert a custom message to the bot

### DIFF
--- a/node-red-contrib-bot-message/bot-send-custom-message.html
+++ b/node-red-contrib-bot-message/bot-send-custom-message.html
@@ -1,0 +1,70 @@
+<script type="text/javascript">
+  RED.nodes.registerType('send-custom-message',{
+      category: 'VISEO_BOT',
+      color: '#3FADB5',
+      defaults: {
+          name:         { value: undefined },
+          delay:        { value: 0 },
+          content:      { value: "payload" },
+          prompt:       { value: undefined },
+          promptText:   { value: "prompt.text" },
+          promptTextType:   { value: "msg" },
+      },
+      inputs:  1, 
+      outputs: 1,
+      icon: "card.svg",
+      oneditprepare: function () {
+          // Typed Input
+          $("#node-input-name").typedInput({ default: 'str', types: ['str'], type: 'str' });
+          $("#node-input-content").typedInput({ default: 'msg', types: ['msg'], type: 'msg' });
+          $("#node-input-promptText").typedInput({ default: 'msg', types: ['msg'], type: 'msg' });
+          // Prompt and speech : show and hide fields
+          $("#node-input-prompt").change( function() {
+              if ($(this).is(":checked")) {
+                  $("#prompt").show();
+                  $("#node-input-promptText").typedInput('show');
+              }
+              else $("#prompt").hide();
+          }).change();
+      },
+      oneditsave: function(){
+          this.delay  = $('#node-input-delay').val()  || 0;
+          this.outputs = 1 ;
+      },
+      label: function() {
+          return this.name || "send-custom-message";
+      },
+      align: "left",
+      paletteLabel: "Custom message",
+      labelStyle: "bot-card-name"
+  });
+</script>
+
+<script type="text/x-red" data-template-name="send-custom-message">
+  <div class="form-row">
+      <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+      <input type="text" id="node-input-name" placeholder="Name">
+  </div>
+  <div class="form-row">
+      <label for="node-input-content"><i class="fa fa-pencil-square-o"></i> Content</label>
+      <input type="text" id="node-input-content" placeholder="payload">
+  </div>
+  <div class="form-row promptable">
+      <br>
+      <label for="node-input-prompt"><i class="fa fa-sign-in"></i> Prompt</label>
+      <input type="checkbox" style="width: auto; vertical-align:top;" id="node-input-prompt"> <span>Require a user input/answer</span>
+  </div>
+  <div class="form-row" id="prompt">
+      <label for="node-input-promptText"></label>
+      <input type="text" id="node-input-promptText" style="width: 80%;" placeholder="prompt.text">
+  </div>
+  <div class="form-row">
+      <label for="node-input-delay"><i class="fa fa-clock-o"></i> Delay</label>
+      <input type="number" min="0" id="node-input-delay" placeholder="0" style="width:100px;">
+      <p style="display: inline-block;"> ms</p>
+  </div>
+</script>
+
+<script type="text/x-red" data-help-name="send-custom-message">
+  <p>A node to send a custom message already formated with the Microsoft bot builder format</p>
+</script>

--- a/node-red-contrib-bot-message/bot-send-custom-message.js
+++ b/node-red-contrib-bot-message/bot-send-custom-message.js
@@ -1,0 +1,61 @@
+const botmgr   = require('node-red-viseo-bot-manager');
+const helper   = require('node-red-viseo-helper');
+
+// --------------------------------------------------------------------------
+//  NODE-RED
+// --------------------------------------------------------------------------
+
+module.exports = function(RED) {
+    const register = function(config) {
+        RED.nodes.createNode(this, config);
+        var node = this;
+
+        this.on('input', (data)  => { input(node, data, config)  });
+    }
+    RED.nodes.registerType("send-custom-message", register, {});
+
+    updateFields = function(opts) {
+        if (opts.name) this.name = opts.name;
+        return;
+    }
+}
+
+const input = (node, data, config) => {
+    let convId = botmgr.getConvId(data)
+
+    data.customReply = helper.getByString(data, config.content);
+
+    // Prepare the prompt
+    if (config.prompt){
+        botmgr.delayCallback(convId, (prompt) => {
+            data.prompt = prompt
+            sendData(node, data, config)
+        })
+    }
+
+    helper.emitAsyncEvent('reply', node, data, config, (newData) => {
+        helper.emitAsyncEvent('replied', node, newData, config, () => {})
+        if (config.prompt) { 
+            return;
+        }
+        sendData(node, newData, config);
+    });
+}
+
+
+const sendData = (node, data, config) => {
+    if (config.prompt && config.promptText) {
+        let promptText = helper.resolve(config.promptText, data, undefined);
+        config.promptText = promptText;
+
+        if (promptText) { 
+            helper.setByString(data, promptText, data.prompt.text, (ex) => { node.warn(ex) });
+        }
+
+        helper.emitAsyncEvent('prompt', node, data, config, (data) => {  
+            return node.send(data);
+        });
+    } else {
+        return node.send(data);
+    }
+}

--- a/node-red-contrib-bot-message/package.json
+++ b/node-red-contrib-bot-message/package.json
@@ -20,7 +20,8 @@
             "bot-event":    "bot-event.js",
             "bot-continue": "bot-continue.js",
             "bot-wrapper":  "bot-wrapper.js",
-            "node-bot-transaction": "bot-transaction.js"
+            "node-bot-transaction": "bot-transaction.js",
+            "send-custom-message": "bot-send-custom-message.js"
         }
     }
 }

--- a/node-red-contrib-botbuilder/nodes/msbot-connect.js
+++ b/node-red-contrib-botbuilder/nodes/msbot-connect.js
@@ -3,17 +3,14 @@
 const fs      = require('fs');
 const path    = require('path');
 const builder = require('botbuilder');
-const logger  = require('../lib/logger.js');
+const logger  = require('../../lib/logger.js');
 const helper  = require('node-red-viseo-helper');
 const botmgr  = require('node-red-viseo-bot-manager');
 
 // Retrieve server
-const msbot    = require('../lib/msbot.js');
-const server   = require('../lib/server.js');
+const msbot    = require('../../lib/msbot.js');
+const server   = require('../../lib/server.js');
 
-const DEFAULT_TYPING_DELAY = 2000;
-const MINIMUM_TYPING_DELAY = 200;
-var globalTypingDelay;
 
 // --------------------------------------------------------------------------
 //  NODE-RED
@@ -25,13 +22,11 @@ module.exports = function(RED) {
     const register = function(config) {
         RED.nodes.createNode(this, config);
         var node = this;
-        
+
         if (config.port) {
             config.port = parseInt(config.port);
         }
 
-        globalTypingDelay = config.delay || DEFAULT_TYPING_DELAY;
-        
         config.appId = node.credentials.appId;
         config.appPassword = node.credentials.appPassword;
 
@@ -50,20 +45,15 @@ module.exports = function(RED) {
 
 let REPLY_HANDLER = {};
 const start = (node, config, RED) => {
-    
-    // restart server
-    if (REPLY_HANDLER[node.id]) helper.removeListener('reply', REPLY_HANDLER[node.id]);
-    server.stop();
-
-    // -------
-
     server.start((err, bot) => {
+
         if (err){
             let msg = "disconnected (" + err.message + ")";
             return node.status({fill:"red", shape:"ring", text: msg});
         }
         node.status({fill:"green", shape:"dot", text:"connected"});
 
+        // Root Dialog
         msbot.bindDialogs(bot, (err, data, type) => {
             helper.emitEvent(type, node, data, config);
             if (type === 'received') { return node.send(data) }
@@ -78,7 +68,6 @@ const start = (node, config, RED) => {
     }, config, RED);
 }
 
-
 // Stop server
 const stop = (node, config, done) => {
     helper.removeListener('reply', REPLY_HANDLER[node.id])
@@ -90,26 +79,36 @@ const stop = (node, config, done) => {
 //  REPLY
 // --------------------------------------------------------------------------
 
-const reply = (bot, node, data, config) => { 
+const reply = (bot, node, data, config) => {
 
     //check it's the last message
     let timestamp = data.message.timestamp
 
     let context = botmgr.getContext(data);
-    
+
     if(timestamp && context.lastMessageDate !== timestamp) {
         return false;
     }
-    
+
     // Assume we send the message to the current user address
     let address = botmgr.getUserAddress(data)
     if (!address || address.carrier !== 'botbuilder') return false;
 
     // Building the message
-    let message = getMessage(node, address, data.reply, timestamp == undefined);
-    if (!message) return false;
+    let message;
 
-    message.address(address);
+    if (data.customReply) {
+        message = data.customReply;
+        message.address = address;                                             
+        message.data = {
+            type: message.type
+        };
+    } else {
+        message = getMessage(node, address, data.reply, timestamp == undefined);
+        if (!message) return false;
+
+        message.address(address);
+    }
 
     let customTyping = (callback) => {
        try {
@@ -139,31 +138,26 @@ const reply = (bot, node, data, config) => {
         doReply();
     } else {
         // Handle the delay
-        let delay;
-        if (!config.delay || config.delay == 0) {
-            delay = globalTypingDelay;
-        } else {
-            delay = config.delay;
-        }
-        delay = delay <= MINIMUM_TYPING_DELAY ? MINIMUM_TYPING_DELAY : delay;
+        let delay  = config.delay !== undefined ? parseInt(config.delay) : 0
         delayReply(delay, data, doReply, customTyping)
     }
 }
 
+const TYPING_DELAY_CONSTANT = 2000;
 const delayReply = (delay, data, callback, customTyping) => {
     let convId  = botmgr.getConvId(data)
     let session = getSession(data)
     if (session){
         msbot.typing(session, () => {
-            let handle = setTimeout(callback, delay);
+            let handle = setTimeout(callback, delay + TYPING_DELAY_CONSTANT)
             msbot.saveTimeout(convId, handle);
         });
     } else {
         customTyping(function() {
-            let handle = setTimeout(callback, delay);
+            let handle = setTimeout(callback, delay + TYPING_DELAY_CONSTANT)
             msbot.saveTimeout(convId, handle);
         })
-        
+
     }
 }
 
@@ -203,8 +197,16 @@ const getMessage = (node, address, replies, isPush) => {
 
     // One or multiple cards
     for (let reply of replies) {
-        
-        let card = getHeroCard(reply);
+
+        //let card = getHeroCard(reply);
+        let card;
+
+        if (reply.type === "AdaptiveCard") {
+            card = getAdaptiveCard(reply);
+        } else {
+            card = getHeroCard(reply);
+        }
+        msg.textFormat("markdown");
         msg.addAttachment(card);
 
         // Only the latest speech is used
@@ -217,7 +219,7 @@ const getMessage = (node, address, replies, isPush) => {
     }
     return msg;
 };
-    
+
 const buildQuickReplyObject = (obj) => {
 
     return {
@@ -230,7 +232,7 @@ const buildQuickReplyObject = (obj) => {
 const buildButtonMessage = (msg, address, reply, isPush) => {
 
 }
-    
+
 const buildRawMessage = (node, msg, opts, address, isPush) => {
 
     var contentShare = false;
@@ -247,11 +249,11 @@ const buildRawMessage = (node, msg, opts, address, isPush) => {
 
         }
 
-        
+
         if (opts.type === 'card') {
             if(!opts.title && !opts.attach && opts.buttons && opts.subtitle) {
 
-                buildFacebookSpecificMessage(msg, "button", opts, isPush);            
+                buildFacebookSpecificMessage(msg, "button", opts, isPush);
                 return true;
             }
         }
@@ -263,7 +265,7 @@ const buildRawMessage = (node, msg, opts, address, isPush) => {
 
 
     if(isPush) {
-        msg.sourceEvent({ facebook : {
+        msg.sourceEvent({ facebook : {
             messaging_type: "MESSAGE_TAG",
             tag: "NON_PROMOTIONAL_SUBSCRIPTION"
 
@@ -273,7 +275,7 @@ const buildRawMessage = (node, msg, opts, address, isPush) => {
     if (opts.type === 'signin') {
         var card = new builder.SigninCard()
         card.text(opts.text);
-        
+
         if (msg.speak && opts.speech) { // Set speech value
             msg.speak(opts.speech === true ? opts.text : opts.speech);
         }
@@ -313,7 +315,7 @@ const buildRawMessage = (node, msg, opts, address, isPush) => {
         return true;
     }
 
-    // Work In Progress: Facebook Quick Buttons: Should be exported to a facebook.js hook 
+    // Work In Progress: Facebook Quick Buttons: Should be exported to a facebook.js hook
     if (opts.type === 'quick') {
         let fText = opts.quicktext;
         if (address.channelId === 'facebook') {
@@ -321,7 +323,7 @@ const buildRawMessage = (node, msg, opts, address, isPush) => {
             fText = fText.replace(/\n/g,'\n\n');
         }
         msg.text(fText);
-        
+
         if (msg.speak && opts.speech) { // Set speech value
             msg.speak(opts.speech === true ? fText : opts.speech);
         }
@@ -410,7 +412,7 @@ const buildFacebookSpecificMessage = (msg, template, reply, isPush) => {
         if (reply.subtext) _speech += reply.subtext ;
         if (reply.subtitle) _speech += reply.subtitle;
     }
-    
+
     if (msg.speak && reply.speech) {
         msg.speak(_speech || '');
     }
@@ -424,7 +426,7 @@ const buildFacebookSpecificMessage = (msg, template, reply, isPush) => {
 const buildFacebookButtonObject = (obj) => {
     if (obj.action === "share") return {
         "type": "element_share",
-        "share_contents": { 
+        "share_contents": {
             "attachment": {
             "type": "template",
             "payload": {
@@ -449,7 +451,7 @@ const buildFacebookButtonObject = (obj) => {
         "type":"web_url",
         "url": obj.value,
         "title": obj.title,
-        "messenger_extensions": "false",  
+        "messenger_extensions": "false",
         //"fallback_url": "https://www.facebook.com/"
     }
     if (obj.action === "call") return {
@@ -507,3 +509,26 @@ const getHeroCard = (opts) => {
 
     return card;
 }
+
+const getAdaptiveCard = (opts) => {
+    opts._speech = '';
+    // Attach Title to card
+    if (!!opts.title) {
+        opts._speech += opts.title + ' ';
+    }
+
+    // Attach Subtext, appears just below subtitle, differs from Subtitle in font styling only.
+    if (!!opts.subtext) {
+        opts._speech += opts.subtext
+    }
+
+    // Attach Subtitle, appears just below Title field, differs from Title in font styling only.
+    if (!!opts.subtitle) {
+        opts._speech += opts.subtitle;
+    }
+
+    return {
+                contentType: "application/vnd.microsoft.card.adaptive",
+                content: opts
+            };
+};


### PR DESCRIPTION
This new node allows to transfert a message already formated with the microsoft bot builder format to the bot. It has the same behaviour as the send card node, but it skips the formating step.
The bot builder node will receive a "reply" event with a data object containing the property "customReply".
This property contains the message already formated and the bot builder will transmit it "as is" to the conversation.