### PR TITLE
add a parameter to define the reset command pattern

### DIFF
--- a/node-red-contrib-botbuilder/lib/server.js
+++ b/node-red-contrib-botbuilder/lib/server.js
@@ -34,7 +34,7 @@ const route = (callback, options, server) => {
     
     
     server.post('/api/v1/messages', connector.listen());
-    bot = bindConnector(connector, options);
+    bot = bindConnector(connector, opt);
 
     callback(undefined, bot);
 };
@@ -55,7 +55,12 @@ const bindConnector = exports.bindConnector = (connector, options) => {
     // global.botbuilder = bot;
 
     // Anytime the major version is incremented any existing conversations will be restarted.
-    bot.use(builder.Middleware.dialogVersion({ version: 1.0, resetCommand: /^reset/i }));
+    bot.use(builder.Middleware.dialogVersion(
+        {
+            version: 1.0,
+            resetCommand: options.resetCommand || /^reset/i
+        }
+    ));
 
     // Logging Middleware
     if (verbose) {

--- a/node-red-contrib-botbuilder/nodes/msbot-connect.html
+++ b/node-red-contrib-botbuilder/nodes/msbot-connect.html
@@ -17,6 +17,7 @@
             name:          { value: undefined },
             project:       { value: undefined },
             port:          { value: undefined },
+            resetCommand:  { value: "/^reset/i" },
             delay:         { value: undefined }
         },
         credentials: {
@@ -33,6 +34,7 @@
             $("#node-input-port").typedInput({        default: 'str', types: ['str'], type: 'str' });
             $("#node-input-appId").typedInput({       default: 'str', types: ['str'], type: 'str' });
             $("#node-input-appPassword").typedInput({ default: 'str', types: ['str'], type: 'str' });
+            $("#node-input-resetCommand").typedInput({default: 're',  types: ['re'],  type: 're' });
             $("#node-input-delay").typedInput({       default: 'num', types: ['num'], type: 'num' });
 
             $("#node-input-delay").change(function(e) {
@@ -74,6 +76,11 @@
         <input type="text" id="node-input-appPassword" style="width:70%;">
     </div>
     <br>
+    <div class="form-row">
+        <label for="node-input-resetCommand"><i class="fa fa-gear"></i> Reset Command</label>
+        <input type="text" id="node-input-resetCommand" style="width:70%;">
+    </div>
+    <br>
     <b>Global message settings </b>
     <div class="form-row">
         <br>
@@ -107,6 +114,8 @@
         <dd>the Azure application ID</dd>
         <dt>AppPass <span class="property-type">string</span></dt>
         <dd>the Azure application password</dd>
+        <dt>Reset Command <span class="property-type">regex</span></dt>
+        <dd>the regular expression used to identify a reset conversation command. If empty, default is /^reset/i</dd>
         <dt>Delay<span class="property-type">number</span></dt>
         <dd>the global delay for your messages. If empty, default is 2000ms. (Minimum 200ms)</dd>
     </dl>

--- a/node-red-contrib-botbuilder/nodes/msbot-connect.js
+++ b/node-red-contrib-botbuilder/nodes/msbot-connect.js
@@ -30,6 +30,13 @@ module.exports = function(RED) {
             config.port = parseInt(config.port);
         }
 
+        if (config.resetCommand) {
+            let lastSlash = config.resetCommand.lastIndexOf('/');
+            let pattern = config.resetCommand.slice(1, lastSlash);
+            let flags = config.resetCommand.slice(lastSlash + 1);
+            config.resetCommand = new RegExp(pattern, flags);
+        }
+
         globalTypingDelay = config.delay || DEFAULT_TYPING_DELAY;
         
         config.appId = node.credentials.appId;


### PR DESCRIPTION
Currently, the regex to detect the reset command is hardcoded in the bot builder node with "/^reset/i".
We have one bot which should answer to the query "reset my password" but it actually reset the conversation.
The pattern use to detect the reset command should be a parameter of the bot builder node so we can personnalize it for each bot.