### PR TITLE
Fix issue when file doesn't exists with get-lines node

### DIFF
--- a/node-red-contrib-file/node-get-lines.js
+++ b/node-red-contrib-file/node-get-lines.js
@@ -36,9 +36,16 @@ const input = (node, data, config) => {
     filepath = path.normalize(filepath);
 
     let myarray = new Array();
+    
+    let readStream = fs.createReadStream(filepath);
+
+    readStream.on('error', function(err) {
+        node.err(err);
+        return node.send(data);
+    })
 
     readline.createInterface({
-        input: fs.createReadStream(filepath) 
+        input: readStream
     })
     .each(function(line) {
         if (split) line = line.split(split);


### PR DESCRIPTION
When the filepath given doesn't exists, it throws an uncaught exception which restarts node-red. This fix handle readStream errors to caught this kind of exception.