### PR TITLE
Add custom metadata to bot message

### DIFF
--- a/node-red-contrib-bot-message/bot-send-card.html
+++ b/node-red-contrib-bot-message/bot-send-card.html
@@ -812,10 +812,8 @@
             </div>
         </section>
         <br/>
-        <br/>
-        <b>Meta datas</b><br/>
         <div class="form-row">
-                <label for="node-input-metadata"><i class="fas fa-database"></i> Metadata</label>
+                <label for="node-input-metadata"><i class="fa fa-database"></i> Metadata</label>
                 <input type="text" id="node-input-metadata" style="width:80%;">
                 <input type="hidden" id="node-input-metadataType">
         </div>

--- a/node-red-contrib-bot-message/bot-send-card.html
+++ b/node-red-contrib-bot-message/bot-send-card.html
@@ -105,6 +105,7 @@
             $("#node-input-attachAdaptiveCard").typedInput({     default: 'str', types: ['msg','global','str'], typeField: $("#node-input-attachTypeAdaptiveCard")});
             $("#node-input-displayedTextSizeAdaptiveCard").typedInput({   types: ['num'], type:'num'});
             $("#node-input-containerSeparatorAdaptiveCard").typedInput({   types: ['str'], type:'str'});
+            $("#node-input-value").typedInput({default: 'str', types: ['msg','flow','global','str','num','bool','json','bin','date','jsonata','env'] ,typeField: $("#node-input-valueType")});
             // Prompt and speech : show and hide fields
             $("#node-input-prompt").change( function() {
                 if ($(this).is(":checked")) {
@@ -808,7 +809,14 @@
                 <input type="hidden" id="node-input-shcardurlType">
             </div>
         </section>
-
+        <br/>
+        <br/>
+        <b>Meta datas</b><br/>
+        <div class="form-row">
+                <label for="node-input-value"><i class="fas fa-database"></i> Metadata</label>
+                <input type="text" id="node-input-value" style="width:80%;">
+                <input type="hidden" id="node-input-valueType">
+        </div>
     </div>
 </script>
 

--- a/node-red-contrib-bot-message/bot-send-card.html
+++ b/node-red-contrib-bot-message/bot-send-card.html
@@ -107,7 +107,7 @@
             $("#node-input-attachAdaptiveCard").typedInput({     default: 'str', types: ['msg','global','str'], typeField: $("#node-input-attachTypeAdaptiveCard")});
             $("#node-input-displayedTextSizeAdaptiveCard").typedInput({   types: ['num'], type:'num'});
             $("#node-input-containerSeparatorAdaptiveCard").typedInput({   types: ['str'], type:'str'});
-            $("#node-input-value").typedInput({default: 'str', types: ['msg','flow','global','str','num','bool','json','bin','date','jsonata','env'] ,typeField: $("#node-input-valueType")});
+            $("#node-input-metadata").typedInput({default: 'str', types: ['msg','flow','global','str','num','bool','json','bin','date','jsonata','env'] ,typeField: $("#node-input-metadataType")});
             // Prompt and speech : show and hide fields
             $("#node-input-prompt").change( function() {
                 if ($(this).is(":checked")) {

--- a/node-red-contrib-bot-message/bot-send-card.html
+++ b/node-red-contrib-bot-message/bot-send-card.html
@@ -74,8 +74,8 @@
             attachAdaptiveCard:       { value: undefined },
             displayedTextSizeAdaptiveCard: {value: undefined},
             containerSeparatorAdaptiveCard: {value: "**"},
-            value :             {value : undefined},
-            valueType : { value : "str"}
+            metadata :             {value : undefined},
+            metadataType : { value : "str"}
         },
         inputs:  1,
         outputs: 1,
@@ -815,9 +815,9 @@
         <br/>
         <b>Meta datas</b><br/>
         <div class="form-row">
-                <label for="node-input-value"><i class="fas fa-database"></i> Metadata</label>
-                <input type="text" id="node-input-value" style="width:80%;">
-                <input type="hidden" id="node-input-valueType">
+                <label for="node-input-metadata"><i class="fas fa-database"></i> Metadata</label>
+                <input type="text" id="node-input-metadata" style="width:80%;">
+                <input type="hidden" id="node-input-metadataType">
         </div>
     </div>
 </script>

--- a/node-red-contrib-bot-message/bot-send-card.html
+++ b/node-red-contrib-bot-message/bot-send-card.html
@@ -74,8 +74,8 @@
             attachAdaptiveCard:       { value: undefined },
             displayedTextSizeAdaptiveCard: {value: undefined},
             containerSeparatorAdaptiveCard: {value: "**"},
-            metadata :             {value : undefined},
-            metadataType : { value : "str"}
+            metadata : { value : "{}" },
+            metadataType : { value : "json" }
         },
         inputs:  1,
         outputs: 1,
@@ -107,7 +107,7 @@
             $("#node-input-attachAdaptiveCard").typedInput({     default: 'str', types: ['msg','global','str'], typeField: $("#node-input-attachTypeAdaptiveCard")});
             $("#node-input-displayedTextSizeAdaptiveCard").typedInput({   types: ['num'], type:'num'});
             $("#node-input-containerSeparatorAdaptiveCard").typedInput({   types: ['str'], type:'str'});
-            $("#node-input-metadata").typedInput({default: 'str', types: ['msg','flow','global','str','num','bool','json','bin','date','jsonata','env'] ,typeField: $("#node-input-metadataType")});
+            $("#node-input-metadata").typedInput({default: 'json', types: ['msg','flow','global','json','jsonata'] ,typeField: $("#node-input-metadataType")});
             // Prompt and speech : show and hide fields
             $("#node-input-prompt").change( function() {
                 if ($(this).is(":checked")) {

--- a/node-red-contrib-bot-message/bot-send-card.html
+++ b/node-red-contrib-bot-message/bot-send-card.html
@@ -73,7 +73,7 @@
             subtextAdaptiveCard:      { value: undefined },
             attachAdaptiveCard:       { value: undefined },
             displayedTextSizeAdaptiveCard: {value: undefined},
-            containerSeparatorAdaptiveCard: {value: "**"},
+            containerSeparatorAdaptiveCard: {value: "##"},
             metadata : { value : undefined },
             metadataType : { value : "str" }
         },

--- a/node-red-contrib-bot-message/bot-send-card.html
+++ b/node-red-contrib-bot-message/bot-send-card.html
@@ -74,8 +74,8 @@
             attachAdaptiveCard:       { value: undefined },
             displayedTextSizeAdaptiveCard: {value: undefined},
             containerSeparatorAdaptiveCard: {value: "**"},
-            metadata : { value : "{}" },
-            metadataType : { value : "json" }
+            metadata : { value : undefined },
+            metadataType : { value : "str" }
         },
         inputs:  1,
         outputs: 1,
@@ -107,7 +107,7 @@
             $("#node-input-attachAdaptiveCard").typedInput({     default: 'str', types: ['msg','global','str'], typeField: $("#node-input-attachTypeAdaptiveCard")});
             $("#node-input-displayedTextSizeAdaptiveCard").typedInput({   types: ['num'], type:'num'});
             $("#node-input-containerSeparatorAdaptiveCard").typedInput({   types: ['str'], type:'str'});
-            $("#node-input-metadata").typedInput({default: 'json', types: ['msg','flow','global','json','jsonata'] ,typeField: $("#node-input-metadataType")});
+            $("#node-input-metadata").typedInput({default: 'str', types: ['msg','flow','global','str','num','bool','json'], typeField: $("#node-input-metadataType")});
             // Prompt and speech : show and hide fields
             $("#node-input-prompt").change( function() {
                 if ($(this).is(":checked")) {
@@ -888,6 +888,9 @@
 
     <p><b>Note:</b> if your bot is a vocal application, then customize the played content: uncheck the <i>Speech</i> checkbox. </p>
     
+    <p>Metadata</p>
+    <p>Custom data associated to the message.</p>
+
     <h3>Details: settings</h3>
     <p>Properties</p>
     <dl class="message-properties">

--- a/node-red-contrib-bot-message/bot-send-card.js
+++ b/node-red-contrib-bot-message/bot-send-card.js
@@ -134,6 +134,7 @@ const input = (node, data, config, reply) => {
     // Emit reply message
     data.reply = replies;
     data._replyid = node.id;
+    data.value = config.value;
     helper.emitAsyncEvent('reply', node, data, config, (newData) => {
         helper.emitAsyncEvent('replied', node, newData, config, () => {})
         if (config.prompt) { 

--- a/node-red-contrib-bot-message/bot-send-card.js
+++ b/node-red-contrib-bot-message/bot-send-card.js
@@ -134,7 +134,11 @@ const input = (node, data, config, reply) => {
     // Emit reply message
     data.reply = replies;
     data._replyid = node.id;
-    data.metadata = config.metadata;
+
+    if (config.metadata) {
+        data.metadata = JSON.parse(config.metadata);
+    }
+
     helper.emitAsyncEvent('reply', node, data, config, (newData) => {
         helper.emitAsyncEvent('replied', node, newData, config, () => {})
         if (config.prompt) { 

--- a/node-red-contrib-bot-message/bot-send-card.js
+++ b/node-red-contrib-bot-message/bot-send-card.js
@@ -1,4 +1,4 @@
-const mustache = require('mustache');
+(function (exports, require, module, __filename, __dirname) { const mustache = require('mustache');
 const i18n     = require('./lib/i18n.js');
 const botmgr   = require('node-red-viseo-bot-manager');
 const helper   = require('node-red-viseo-helper');
@@ -136,7 +136,29 @@ const input = (node, data, config, reply) => {
     data._replyid = node.id;
 
     if (config.metadata) {
-        data.metadata = JSON.parse(config.metadata);
+        switch (config.metadataType) {
+            case 'msg':
+                data.metadata = data[config.metadata];
+                break;
+            case 'flow':
+                data.metadata = node.context().flow.get(config.metadata);
+                break;
+            case 'global':
+                data.metadata = node.context().global.get(config.metadata);
+                break;
+            case 'str':
+                data.metadata = config.metadata;
+                break;
+            case 'num':
+                data.metadata = +config.metadata;
+                break;
+            case 'bool':
+                data.metadata = config.metadata === 'true';
+                break;
+            case 'json':
+                data.metadata = JSON.parse(config.metadata);
+                break;
+        }
     }
 
     helper.emitAsyncEvent('reply', node, data, config, (newData) => {
@@ -609,3 +631,4 @@ const buildReplyAdaptiveCard = (locale, data, config, reply) => {
         buildAdaptiveCardJson(textToShow, reply.body, separator);
     }
 }
+});

--- a/node-red-contrib-bot-message/bot-send-card.js
+++ b/node-red-contrib-bot-message/bot-send-card.js
@@ -1,4 +1,4 @@
-(function (exports, require, module, __filename, __dirname) { const mustache = require('mustache');
+const mustache = require('mustache');
 const i18n     = require('./lib/i18n.js');
 const botmgr   = require('node-red-viseo-bot-manager');
 const helper   = require('node-red-viseo-helper');
@@ -134,7 +134,7 @@ const input = (node, data, config, reply) => {
     // Emit reply message
     data.reply = replies;
     data._replyid = node.id;
-
+    
     if (config.metadata) {
         switch (config.metadataType) {
             case 'msg':
@@ -631,4 +631,3 @@ const buildReplyAdaptiveCard = (locale, data, config, reply) => {
         buildAdaptiveCardJson(textToShow, reply.body, separator);
     }
 }
-});

--- a/node-red-contrib-bot-message/bot-send-card.js
+++ b/node-red-contrib-bot-message/bot-send-card.js
@@ -88,12 +88,12 @@ const getButtons = (locale, config, data) => {
             if (!config.shcardbuttonType) shcardbutton = marshall(locale, shcardbutton,  data, '');
             else if (config.shcardbuttonType !== 'str') {
                 let loc = (config.shcardbuttonType === 'global') ? node.context().global : data;
-                shcardbutton = helper.getByString(loc, shcardbutton);value
+                shcardbutton = helper.getByString(loc, shcardbutton);
             }
 
             button.sharedCard = {
                 title:  shcardtitle,
-                text:   marshall(locale, config.shcardtext,   data, 'value
+                text:   marshall(locale, config.shcardtext,   data, ''),
                 media:  shcardimage,
                 button: shcardbutton,
                 url:    shcardurl
@@ -134,7 +134,7 @@ const input = (node, data, config, reply) => {
     // Emit reply message
     data.reply = replies;
     data._replyid = node.id;
-    data.value = config.value;
+    data.metadata = config.metadata;
     helper.emitAsyncEvent('reply', node, data, config, (newData) => {
         helper.emitAsyncEvent('replied', node, newData, config, () => {})
         if (config.prompt) { 
@@ -177,7 +177,11 @@ const buildReply = (node, data, config) => {
 
     // Simple text message
     if (config.sendType === 'text'){
-        buildReplyText(locale, data, config, reply);
+        let text = marshall(locale, config.text, data, '');
+        if (config.random){
+            let txt = text.split('\n');
+            text = txt[Math.round(Math.random() * (txt.length-1))]
+        }
 
         reply.text = text;
         if (reply.speech === undefined) reply.speech = text;
@@ -232,7 +236,6 @@ const buildReply = (node, data, config) => {
         buttonsStack.push(data, buttons);
         reply.buttons = buttons;
 
-        // Quick replies
         if (config.sendType === 'quick') {
             reply.quicktext = marshall(locale, config.quicktext, data, '');
             if (config.random){
@@ -246,6 +249,22 @@ const buildReply = (node, data, config) => {
             let title = config.title;
             let attach = config.attach;
 
+            if (!config.titleType) title = marshall(locale, title,  data, '');
+            else if (config.titleType !== 'str') {
+                let loc = (config.titleType === 'global') ? node.context().global : data;
+                title = helper.getByString(loc, title);
+            }
+            if (!config.attachType) attach = marshall(locale, attach,  data, '');
+            else if (config.attachType !== 'str') {
+                let loc = (config.attachType === 'global') ? node.context().global : data;
+                attach = helper.getByString(loc, attach);
+            }
+            
+            reply.title =    title;
+            reply.subtitle = marshall(locale, config.subtitle,  data, '');
+            reply.subtext =  marshall(locale, config.subtext,   data, '');
+            reply.attach =   attach;
+            if (reply.speech === undefined) reply.speech = reply.subtitle || reply.subtext;
         }
         else if (config.sendType === 'adaptiveCard') {
             buildReplyAdaptiveCard(locale, data, config, reply);

--- a/node-red-contrib-botbuilder/nodes/msbot-connect.js
+++ b/node-red-contrib-botbuilder/nodes/msbot-connect.js
@@ -127,8 +127,8 @@ const reply = (bot, node, data, config) => {
 
         message.address(address);
         
-        //Printing the metadatas
-        if(data.value) message.data.value = data.value;
+        // Adding the metadata
+        if(data.metadata) message.data.value = data.metadata;
     }
 
     let customTyping = (callback) => {

--- a/node-red-contrib-botbuilder/nodes/msbot-connect.js
+++ b/node-red-contrib-botbuilder/nodes/msbot-connect.js
@@ -126,6 +126,9 @@ const reply = (bot, node, data, config) => {
         if (!message) return false;
 
         message.address(address);
+        
+        //Printing the metadatas
+        if(data.value) message.data.value = data.value;
     }
 
     let customTyping = (callback) => {


### PR DESCRIPTION
Add a new field to "send-message" node to associate custom data to a message sent to a bot.
The bot builder has also been updated to handle this metadata (see https://docs.microsoft.com/en-us/azure/bot-service/rest-api/bot-framework-rest-connector-api-reference?view=azure-bot-service-4.0#activity-object, the 'value' property).