### PR TITLE
add before-reply event

### DIFF
--- a/node-red-contrib-bot-message/bot-event.html
+++ b/node-red-contrib-bot-message/bot-event.html
@@ -28,6 +28,7 @@
             <option value="prompt-unexpected">Prompt unexpected text</option>
             <option value="received">Received</option>
             <option value="replied">Replied</option>
+            <option value="before-reply">Before reply</option>
             <option value="reply">Reply</option>
             <option value="greeting">Greeting</option>
         </select>
@@ -53,8 +54,10 @@
         <dd>when the connector just received a message from the user</dd>
         <dt>Replied </dt>
         <dd>when the bot replied to the user</dd>
+        <dt>Before reply <span class="property-type">needs Continue</span></dt>
+        <dd>When the bot prepared the message but before it send it to the user</dd>
         <dt>Reply </dt>
-        <dd>when the bot just prepared the message to reply to the user</dd>
+        <dd>when the bot send the reply to the user</dd>
     </dl>
 
     <h4>Precedence</h4>

--- a/node-red-contrib-bot-message/bot-send-card.js
+++ b/node-red-contrib-bot-message/bot-send-card.js
@@ -161,12 +161,14 @@ const input = (node, data, config, reply) => {
         }
     }
 
-    helper.emitAsyncEvent('reply', node, data, config, (newData) => {
-        helper.emitAsyncEvent('replied', node, newData, config, () => {})
-        if (config.prompt) { 
-            return; 
-        }
-        sendData(node, newData, config);
+    helper.emitAsyncEvent('before-reply', node, data, config, (newData) => {
+        helper.emitAsyncEvent('reply', node, newData, config, (otherData) => {
+            helper.emitAsyncEvent('replied', node, otherData, config, () => {})
+            if (config.prompt) { 
+                return; 
+            }
+            sendData(node, otherData, config);
+        });
     });
 }
 

--- a/node-red-contrib-bot-message/bot-send-custom-message.js
+++ b/node-red-contrib-bot-message/bot-send-custom-message.js
@@ -33,12 +33,14 @@ const input = (node, data, config) => {
         })
     }
 
-    helper.emitAsyncEvent('reply', node, data, config, (newData) => {
-        helper.emitAsyncEvent('replied', node, newData, config, () => {})
-        if (config.prompt) { 
-            return;
-        }
-        sendData(node, newData, config);
+    helper.emitAsyncEvent('before-reply', node, data, config, (newData) => {
+        helper.emitAsyncEvent('reply', node, newData, config, (otherData) => {
+            helper.emitAsyncEvent('replied', node, otherData, config, () => {})
+            if (config.prompt) { 
+                return; 
+            }
+            sendData(node, otherData, config);
+        });
     });
 }
 


### PR DESCRIPTION
Add a "before-reply" event in bot-event and bot-send-card to be abble to intercept a bot reply.

When a bot-event is configured with "before-reply", the bot replies will be catched. A bot-continue node will be required after the bot-event to finish the process and transmit the message to the user.