### PR TITLE
add a customisable title for show-card button on the adaptive card

### DIFF
--- a/node-red-contrib-bot-message/bot-send-card.html
+++ b/node-red-contrib-bot-message/bot-send-card.html
@@ -76,7 +76,9 @@
             displayedTextSizeAdaptiveCard: {value: undefined},
             containerSeparatorAdaptiveCard: {value: "##"},
             metadata : { value : undefined },
-            metadataType : { value : "str" }
+            metadataType : { value : "str" },
+            titleShowCardAction: { value: undefined },
+            titleShowCardActionType: { value: "str" }
         },
         inputs:  1,
         outputs: 1,
@@ -109,6 +111,7 @@
             $("#node-input-displayedTextSizeAdaptiveCard").typedInput({   types: ['num'], type:'num'});
             $("#node-input-containerSeparatorAdaptiveCard").typedInput({   types: ['str'], type:'str'});
             $("#node-input-metadata").typedInput({default: 'str', types: ['msg','flow','global','str','num','bool','json'], typeField: $("#node-input-metadataType")});
+            $("#node-input-titleShowCardAction").typedInput({default: 'str', types: ['msg','global','str','flow'], typeField: $("#node-input-titleShowCardActionType")});
             // Prompt and speech : show and hide fields
             $("#node-input-prompt").change( function() {
                 if ($(this).is(":checked")) {
@@ -687,12 +690,17 @@
             <div class="form-row">
                 <label  for="node-input-displayedTextSizeAdaptiveCard"> Wrap text up to </label>
                 <input type="number" id="node-input-displayedTextSizeAdaptiveCard">
-                </div>
-                <div class="form-row">
-                    <label for="node-input-containerSeparatorAdaptiveCard"> Container separator </label>
-                    <input type="text" id="node-input-containerSeparatorAdaptiveCard">
-                </div>
-                <div class="form-row">
+            </div>
+            <div class="form-row">
+                <label for="node-input-containerSeparatorAdaptiveCard"> Container separator </label>
+                <input type="text" id="node-input-containerSeparatorAdaptiveCard">
+            </div>
+            <div class="form-row">
+                <label for="node-input-titleShowCardAction"><i class="fa fa-pencil-square-o"></i> Show card button title</label>
+                <input type="text" id="node-input-titleShowCardAction"  style="width:80%;">
+                <input type="hidden" id="node-input-titleShowCardActionType">
+            </div>
+            <div class="form-row">
                 <label for="node-input-attachAdaptiveCard"><i class="fa fa-image"></i> Image</label>
                 <input type="text" id="node-input-attachAdaptiveCard" style="width:80%;" placeholder="http://path/to/card/image">
                 <input type="hidden" id="node-input-attachTypeAdaptiveCard">

--- a/node-red-contrib-bot-message/bot-send-card.js
+++ b/node-red-contrib-bot-message/bot-send-card.js
@@ -523,6 +523,7 @@ const buildReplyAdaptiveCard = (locale, data, config, reply) => {
     let subtext = config.textAdaptiveCard;
     let separator = config.containerSeparatorAdaptiveCard;
     let displayedTextSize = config.displayedTextSizeAdaptiveCard;
+    let titleShowCardAction = config.titleShowCardAction || 'More';
    
     if (!separator) {
         separator = "**";
@@ -531,6 +532,20 @@ const buildReplyAdaptiveCard = (locale, data, config, reply) => {
     if (!displayedTextSize) {
         // if not defined value, then don't wrap, display up to 100k characters.
         displayedTextSize = 100000;
+    }
+
+    switch (config.titleShowCardActionType) {
+        case 'str':
+            titleShowCardAction = marshall(locale, titleShowCardAction,  data, '');
+            break;
+        case 'global':
+            titleShowCardAction = helper.getByString(node.context().global, titleShowCardAction);
+            break;
+        case 'flow':
+            titleShowCardAction = helper.getByString(node.context().flow, titleShowCardAction);
+            break;
+        default:
+            titleShowCardAction = 'More';
     }
 
     if (!config.titleTypeAdaptiveCard) title = marshall(locale, title,  data, '');
@@ -579,7 +594,7 @@ const buildReplyAdaptiveCard = (locale, data, config, reply) => {
         tmp = textToShow.substring(attrIndex);
 
         //reply.actions.push({"type": "Action.ShowCard", "title": "More", "card": {"type": 'AdaptiveCard', "body": [{"type": "TextBlock", "text": tmp, "size": "default", "wrap": true}]}});
-        reply.actions.push({"type": "Action.ShowCard", "title": "More", "card": {"type": 'AdaptiveCard', "body": []}});
+        reply.actions.push({"type": "Action.ShowCard", "title": titleShowCardAction, "card": {"type": 'AdaptiveCard', "body": []}});
         buildAdaptiveCardJson(tmp, reply.actions[0].card.body, separator);
         
     } else {


### PR DESCRIPTION
Problem description: the title of any show action button is hard-coded as 'More' on the AdaptiveCard.
It should be customisable/ generic in order to meet the needs of globalisation.

Changements: add an new setting of type Global/Flow/String to the AdaptiveCard template.
![Capture](https://user-images.githubusercontent.com/15153981/61623777-9dcc2c00-ac77-11e9-8079-080a93a02730.JPG)
![Capture](https://user-images.githubusercontent.com/15153981/61623837-bc322780-ac77-11e9-9d44-743ec11ecac8.JPG)

