### PR TITLE
fix bad renaming for logstash node

### DIFF
--- a/node-red-contrib-log/node-logstash.html
+++ b/node-red-contrib-log/node-logstash.html
@@ -1,5 +1,5 @@
 <script type="text/javascript">
-    RED.nodes.registerType('logstach',{
+    RED.nodes.registerType('logstash',{
         category: '📊_logs',
         color: '#3FADB5',
         defaults: { 


### PR DESCRIPTION
Node-red-contrib-viseo-log@0.4.0 introduces a renaming of the logstash node but one variable was missing. It causes the following error in the node-red UI:

> Failed to load 'node-red-contrib-viseo-log/log-logstash'
TypeError: Cannot set property 'added' of undefined
