### PR TITLE
Update `airtable` to latest version, v0.7.2

### DIFF
--- a/node-red-contrib-airtable/package.json
+++ b/node-red-contrib-airtable/package.json
@@ -4,7 +4,7 @@
   "description": "VISEO Bot Maker - Airtable",
   "dependencies": {
     "node-red-viseo-helper": "~0.3.0",
-    "airtable": "~0.7.1"
+    "airtable": "~0.7.2"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This updates `airtable` to the latest version, v0.7.2. [See the changelog][1] for more info on what changed.

[1]: https://github.com/Airtable/airtable.js/blob/v0.7.2/CHANGELOG.md