### PR TITLE
Fix wrong warning

### DIFF
--- a/node-red-contrib-log/node-azure-appinsight.js
+++ b/node-red-contrib-log/node-azure-appinsight.js
@@ -58,7 +58,10 @@ module.exports = function (RED) {
         RED.nodes.createNode(this, config);
         const node = this;
         const conf = RED.nodes.getNode(config.configuration);
-        node.status({ fill: 'red', shape: 'ring', text: 'Missing configuration' });
+        
+        if (!conf) {
+            node.status({ fill: 'red', shape: 'ring', text: 'Missing configuration' });
+        }
 
         if (!conf || !conf.credentials.key) return;
 


### PR DESCRIPTION
Remove warning "missing configuration" when configuration is given.