### PR TITLE
fix typo attach

### DIFF
--- a/node-red-contrib-bot-message/bot-send-card.js
+++ b/node-red-contrib-bot-message/bot-send-card.js
@@ -570,8 +570,7 @@ const buildReplyAdaptiveCard = (RED, node, locale, data, config, reply) => {
     title = marshall(locale, title,  data, '');
 
     attach = helper.getContextValue(RED, node, data, attach || '', config.attachTypeAdaptiveCard || 'str');
-    titattachle = marshall(locale, attach,  data, '');
-
+    attach = marshall(locale, attach,  data, '');
 
     reply.type = 'AdaptiveCard';
     reply.title = title;


### PR DESCRIPTION
Hello @TothiViseo 

Here is the Issue that I found: 
Cannot change the type of Attach of Adaptive-Card.
![type-adaptiveCard](https://user-images.githubusercontent.com/15153981/74419938-f00aaf80-4e4a-11ea-9ef6-68ec1bceee2d.JPG)


Cause: there is a typo 'titattachle' in the function buildReplyAdaptiveCard. 


